### PR TITLE
No-helpline counselors are added when filtering for helpline

### DIFF
--- a/functions/populateCounselors.ts
+++ b/functions/populateCounselors.ts
@@ -67,7 +67,9 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
       });
 
       if (helpline) {
-        const filtered = withHelpline.filter(w => w.helpline === helpline);
+        const filtered = withHelpline.filter(
+          w => w.helpline === helpline || w.helpline === '' || w.helpline === undefined,
+        );
         const workerSummaries = filtered.map(({ fullName, sid }) => ({ fullName, sid }));
 
         send(response)(200)({ workerSummaries })(callback);


### PR DESCRIPTION
Jira : https://bugs.benetech.org/browse/CHI-111

- No-helpline counselors are added to the result when filtering for helpline (excluding only those with a helpline that is not empty nor equal to the given)