### PR TITLE
Add transfer task functionality

### DIFF
--- a/functions/transferChatResolve.ts
+++ b/functions/transferChatResolve.ts
@@ -1,0 +1,125 @@
+import '@twilio-labs/serverless-runtime-types';
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  error400,
+  error500,
+  success,
+} from 'tech-matters-serverless-helpers';
+
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: string;
+  CHAT_SERVICE_SID: string;
+};
+
+export type Body = {
+  closeSid?: string;
+  keepSid?: string;
+  kickMember?: string;
+  newStatus?: string;
+};
+
+export const handler: ServerlessFunctionSignature = TokenValidator(
+  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
+    const client = context.getTwilioClient();
+
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+
+    const { closeSid, keepSid, kickMember, newStatus } = event;
+
+    try {
+      if (closeSid === undefined) {
+        resolve(error400('closeSid'));
+        return;
+      }
+      if (keepSid === undefined) {
+        resolve(error400('keepSid'));
+        return;
+      }
+      if (kickMember === undefined) {
+        resolve(error400('kickMember'));
+        return;
+      }
+
+      // retrieve attributes of the closing task
+      const closingTask = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(closeSid)
+        .fetch();
+
+      const closingAttributes = JSON.parse(closingTask.attributes);
+      const keepingChannel = closingAttributes.channelSid;
+
+      // Set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
+      const updatedClosingAttributes = {
+        ...closingAttributes,
+        channelSid: 'CH00000000000000000000000000000000',
+        proxySessionSID: 'KC00000000000000000000000000000000',
+      };
+
+      await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(closeSid)
+        .update({ attributes: JSON.stringify(updatedClosingAttributes) });
+
+      // Close the Task and set the propper status
+      const closedTask = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(closeSid)
+        .update({
+          assignmentStatus: 'completed',
+          reason: 'task transferred',
+          attributes: JSON.stringify({
+            ...updatedClosingAttributes,
+            transferMeta: {
+              ...updatedClosingAttributes.transferMeta,
+              transferStatus: newStatus || 'completed',
+            },
+          }),
+        });
+
+      // kick the counselor that is not required anymore
+      if (kickMember)
+        await client.chat
+          .services(context.CHAT_SERVICE_SID)
+          .channels(keepingChannel)
+          .members(kickMember)
+          .remove();
+
+      // retrieve attributes of the preserved task
+      const keepingTask = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(keepSid)
+        .fetch();
+
+      const keepingAttributes = JSON.parse(keepingTask.attributes);
+
+      // update the status of the task that is preserved
+      const updatedKeepingAttributes = {
+        ...keepingAttributes,
+        transferMeta: {
+          ...keepingAttributes.transferMeta,
+          transferStatus: newStatus || 'completed',
+        },
+      };
+
+      const keptTask = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(keepSid)
+        .update({ attributes: JSON.stringify(updatedKeepingAttributes) });
+
+      resolve(success({ closed: closedTask.sid, kept: keptTask.sid }));
+    } catch (err) {
+      resolve(error500(err));
+    }
+  },
+);

--- a/functions/transferChatResolve.ts
+++ b/functions/transferChatResolve.ts
@@ -23,18 +23,119 @@ type EnvVars = {
 export type Body = {
   closeSid?: string;
   keepSid?: string;
-  kickMember?: string;
+  memberToKick?: string;
   newStatus?: string;
 };
 
+async function closeTask(
+  context: Context<EnvVars>,
+  sid: string,
+  taskToCloseAttributes: any,
+  newStatus: string,
+) {
+  // set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
+  const newTaskToCloseAttributes = {
+    ...taskToCloseAttributes,
+    channelSid: 'CH00000000000000000000000000000000',
+    proxySessionSID: 'KC00000000000000000000000000000000',
+  };
+
+  const client = context.getTwilioClient();
+
+  await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(sid)
+    .update({ attributes: JSON.stringify(newTaskToCloseAttributes) });
+
+  // close the Task and set the proper status
+  const closedTask = await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(sid)
+    .update({
+      assignmentStatus: 'completed',
+      reason: 'task transferred',
+      attributes: JSON.stringify({
+        ...newTaskToCloseAttributes,
+        transferMeta: {
+          ...newTaskToCloseAttributes.transferMeta,
+          transferStatus: newStatus,
+        },
+      }),
+    });
+
+  return closedTask;
+}
+
+async function kickMember(context: Context<EnvVars>, memberToKick: string, chatChannel: string) {
+  const client = context.getTwilioClient();
+
+  // kick out the counselor that is not required anymore
+  if (memberToKick) {
+    const memberKicked = await client.chat
+      .services(context.CHAT_SERVICE_SID)
+      .channels(chatChannel)
+      .members(memberToKick)
+      .remove();
+
+    return memberKicked;
+  }
+
+  return false;
+}
+
+async function closeTaskAndKick(context: Context<EnvVars>, body: Required<Body>) {
+  const client = context.getTwilioClient();
+
+  // retrieve attributes of the task to close
+  const taskToClose = await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(body.closeSid)
+    .fetch();
+  const taskToCloseAttributes = JSON.parse(taskToClose.attributes);
+  const { channelSid } = taskToCloseAttributes;
+
+  const [closedTask] = await Promise.all([
+    closeTask(context, body.closeSid, taskToCloseAttributes, body.newStatus),
+    kickMember(context, body.memberToKick, channelSid),
+  ]);
+
+  return closedTask;
+}
+
+async function updateTaskToKeep(context: Context<EnvVars>, body: Required<Body>) {
+  const client = context.getTwilioClient();
+
+  // retrieve attributes of the preserved task
+  const taskToKeep = await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(body.keepSid)
+    .fetch();
+
+  const taskToKeepAttributes = JSON.parse(taskToKeep.attributes);
+
+  // update the status of the task that is preserved
+  const newTaskToKeepAttributes = {
+    ...taskToKeepAttributes,
+    transferMeta: {
+      ...taskToKeepAttributes.transferMeta,
+      transferStatus: body.newStatus,
+    },
+  };
+
+  const keptTask = await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(body.keepSid)
+    .update({ attributes: JSON.stringify(newTaskToKeepAttributes) });
+
+  return keptTask;
+}
+
 export const handler: ServerlessFunctionSignature = TokenValidator(
   async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
-    const client = context.getTwilioClient();
-
     const response = responseWithCors();
     const resolve = bindResolve(callback)(response);
 
-    const { closeSid, keepSid, kickMember, newStatus } = event;
+    const { closeSid, keepSid, memberToKick, newStatus } = event;
 
     try {
       if (closeSid === undefined) {
@@ -45,77 +146,21 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
         resolve(error400('keepSid'));
         return;
       }
-      if (kickMember === undefined) {
-        resolve(error400('kickMember'));
+      if (memberToKick === undefined) {
+        resolve(error400('memberToKick'));
+        return;
+      }
+      if (newStatus === undefined) {
+        resolve(error400('newStatus'));
         return;
       }
 
-      // retrieve attributes of the closing task
-      const closingTask = await client.taskrouter
-        .workspaces(context.TWILIO_WORKSPACE_SID)
-        .tasks(closeSid)
-        .fetch();
+      const validBody = { closeSid, keepSid, memberToKick, newStatus };
 
-      const closingAttributes = JSON.parse(closingTask.attributes);
-      const keepingChannel = closingAttributes.channelSid;
-
-      // Set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
-      const updatedClosingAttributes = {
-        ...closingAttributes,
-        channelSid: 'CH00000000000000000000000000000000',
-        proxySessionSID: 'KC00000000000000000000000000000000',
-      };
-
-      await client.taskrouter
-        .workspaces(context.TWILIO_WORKSPACE_SID)
-        .tasks(closeSid)
-        .update({ attributes: JSON.stringify(updatedClosingAttributes) });
-
-      // Close the Task and set the propper status
-      const closedTask = await client.taskrouter
-        .workspaces(context.TWILIO_WORKSPACE_SID)
-        .tasks(closeSid)
-        .update({
-          assignmentStatus: 'completed',
-          reason: 'task transferred',
-          attributes: JSON.stringify({
-            ...updatedClosingAttributes,
-            transferMeta: {
-              ...updatedClosingAttributes.transferMeta,
-              transferStatus: newStatus || 'completed',
-            },
-          }),
-        });
-
-      // kick the counselor that is not required anymore
-      if (kickMember)
-        await client.chat
-          .services(context.CHAT_SERVICE_SID)
-          .channels(keepingChannel)
-          .members(kickMember)
-          .remove();
-
-      // retrieve attributes of the preserved task
-      const keepingTask = await client.taskrouter
-        .workspaces(context.TWILIO_WORKSPACE_SID)
-        .tasks(keepSid)
-        .fetch();
-
-      const keepingAttributes = JSON.parse(keepingTask.attributes);
-
-      // update the status of the task that is preserved
-      const updatedKeepingAttributes = {
-        ...keepingAttributes,
-        transferMeta: {
-          ...keepingAttributes.transferMeta,
-          transferStatus: newStatus || 'completed',
-        },
-      };
-
-      const keptTask = await client.taskrouter
-        .workspaces(context.TWILIO_WORKSPACE_SID)
-        .tasks(keepSid)
-        .update({ attributes: JSON.stringify(updatedKeepingAttributes) });
+      const [closedTask, keptTask] = await Promise.all([
+        closeTaskAndKick(context, validBody),
+        updateTaskToKeep(context, validBody),
+      ]);
 
       resolve(success({ closed: closedTask.sid, kept: keptTask.sid }));
     } catch (err) {

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -140,6 +140,7 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
         targetSid, // update task attributes to include the required targetSid on the task (workerSid or a queueSid)
         transferTargetType: targetSid.startsWith('WK') ? 'worker' : 'queue',
       };
+
       // create New task
       const newTask = await client.taskrouter
         .workspaces(context.TWILIO_WORKSPACE_SID)

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -1,0 +1,107 @@
+import '@twilio-labs/serverless-runtime-types';
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  error400,
+  error500,
+  success,
+} from 'tech-matters-serverless-helpers';
+
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: string;
+};
+
+export type Body = {
+  taskSid?: string;
+  targetSid?: string;
+  workerName?: string;
+  mode?: string;
+};
+
+export const handler: ServerlessFunctionSignature = TokenValidator(
+  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
+    const client = context.getTwilioClient();
+
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+
+    const { taskSid, targetSid, workerName, mode } = event;
+
+    try {
+      if (taskSid === undefined) {
+        resolve(error400('taskSid'));
+        return;
+      }
+      if (targetSid === undefined) {
+        resolve(error400('targetSid'));
+        return;
+      }
+      if (workerName === undefined) {
+        resolve(error400('workerName'));
+        return;
+      }
+      if (mode === undefined) {
+        resolve(error400('mode'));
+        return;
+      }
+
+      // retrieve attributes of the original task
+      const originalTask = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(taskSid)
+        .fetch();
+
+      const originalAttributes = JSON.parse(originalTask.attributes);
+
+      const newAttributes = {
+        ...originalAttributes,
+        conversations: originalAttributes.conversation // set up attributes of the new task to link them to the original task in Flex Insights
+          ? originalAttributes.conversation
+          : { conversation_id: taskSid },
+        ignoreAgent: workerName, // update task attributes to ignore the agent who transferred the task
+        targetSid, // update task attributes to include the required targetSid on the task (workerSid or a queueSid)
+        transferTargetType: targetSid.startsWith('WK') ? 'worker' : 'queue',
+      };
+      // create New task
+      const newTask = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks.create({
+          workflowSid: context.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
+          taskChannel: originalTask.taskChannelUniqueName,
+          attributes: JSON.stringify(newAttributes),
+        });
+
+      if (mode === 'COLD') {
+        // Set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
+        const updatedAttributes = {
+          ...originalAttributes,
+          channelSid: 'CH00000000000000000000000000000000',
+          proxySessionSID: 'KC00000000000000000000000000000000',
+        };
+
+        await client.taskrouter
+          .workspaces(context.TWILIO_WORKSPACE_SID)
+          .tasks(taskSid)
+          .update({ attributes: JSON.stringify(updatedAttributes) });
+
+        // Close the original Task
+        await client.taskrouter
+          .workspaces(context.TWILIO_WORKSPACE_SID)
+          .tasks(taskSid)
+          .update({ assignmentStatus: 'completed', reason: 'task transferred' });
+      }
+
+      resolve(success({ taskSid: newTask.sid }));
+    } catch (err) {
+      resolve(error500(err));
+    }
+  },
+);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -114,3 +114,4 @@ export default {
   backupEnv,
   restoreEnv
 };
+

--- a/tests/transferChatResolve.test.ts
+++ b/tests/transferChatResolve.test.ts
@@ -73,6 +73,7 @@ const baseContext = {
                       return {
                         remove: async () => {
                           channels[channelSid] = channels[channelSid].filter(v => v !== memberSid);
+                          return true;
                         },
                       };
 
@@ -113,20 +114,26 @@ describe('transferChatResolve', () => {
     const event1: Body = {
       closeSid: undefined,
       keepSid: 'task2',
-      kickMember: 'worker1',
-      newStatus: 'completed',
+      memberToKick: 'worker1',
+      newStatus: 'accepted',
     };
     const event2: Body = {
       closeSid: 'task1',
       keepSid: undefined,
-      kickMember: 'worker1',
-      newStatus: 'completed',
+      memberToKick: 'worker1',
+      newStatus: 'accepted',
     };
     const event3: Body = {
       closeSid: 'task1',
       keepSid: 'task2',
-      kickMember: undefined,
-      newStatus: 'completed',
+      memberToKick: undefined,
+      newStatus: 'accepted',
+    };
+    const event4: Body = {
+      closeSid: 'task1',
+      keepSid: 'task2',
+      memberToKick: 'worker1',
+      newStatus: undefined,
     };
 
     const callback: ServerlessCallback = (err, result) => {
@@ -136,7 +143,9 @@ describe('transferChatResolve', () => {
     };
 
     await Promise.all(
-      [{}, event1, event2, event3].map(event => transferChatResolve(baseContext, event, callback)),
+      [{}, event1, event2, event3, event4].map(event =>
+        transferChatResolve(baseContext, event, callback),
+      ),
     );
   });
 
@@ -144,14 +153,14 @@ describe('transferChatResolve', () => {
     const event1: Body = {
       closeSid: 'non existing',
       keepSid: 'task2',
-      kickMember: '',
-      newStatus: 'completed',
+      memberToKick: '',
+      newStatus: 'accepted',
     };
     const event2: Body = {
       closeSid: 'task1',
       keepSid: 'non existing',
-      kickMember: '',
-      newStatus: 'completed',
+      memberToKick: '',
+      newStatus: 'accepted',
     };
 
     const callback1: ServerlessCallback = (err, result) => {
@@ -178,19 +187,19 @@ describe('transferChatResolve', () => {
     const event: Body = {
       closeSid: 'task1',
       keepSid: 'task2',
-      kickMember: 'worker1',
-      newStatus: 'completed',
+      memberToKick: 'worker1',
+      newStatus: 'accepted',
     };
 
     const expected = { closed: 'task1', kept: 'task2' };
     const expectedClosedAttr = JSON.stringify({
       channelSid: 'CH00000000000000000000000000000000',
       proxySessionSID: 'KC00000000000000000000000000000000',
-      transferMeta: { transferStatus: 'completed' },
+      transferMeta: { transferStatus: 'accepted' },
     });
     const expectedKeptAttr = JSON.stringify({
       channelSid: 'channel',
-      transferMeta: { transferStatus: 'completed' },
+      transferMeta: { transferStatus: 'accepted' },
     });
 
     const callback: ServerlessCallback = (err, result) => {
@@ -216,19 +225,19 @@ describe('transferChatResolve', () => {
     const event: Body = {
       closeSid: 'task2',
       keepSid: 'task1',
-      kickMember: 'worker1',
-      newStatus: 'completed',
+      memberToKick: 'worker1',
+      newStatus: 'accepted',
     };
 
     const expected = { closed: 'task2', kept: 'task1' };
     const expectedClosedAttr = JSON.stringify({
       channelSid: 'CH00000000000000000000000000000000',
       proxySessionSID: 'KC00000000000000000000000000000000',
-      transferMeta: { transferStatus: 'completed' },
+      transferMeta: { transferStatus: 'accepted' },
     });
     const expectedKeptAttr = JSON.stringify({
       channelSid: 'channel',
-      transferMeta: { transferStatus: 'completed' },
+      transferMeta: { transferStatus: 'accepted' },
     });
 
     const callback: ServerlessCallback = (err, result) => {

--- a/tests/transferChatResolve.test.ts
+++ b/tests/transferChatResolve.test.ts
@@ -1,0 +1,252 @@
+import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { handler as transferChatResolve, Body } from '../functions/transferChatResolve';
+
+import helpers, { MockedResponse } from './helpers';
+
+let tasks: any[] = [];
+const channels: { [x: string]: string[] } = {};
+
+const createTask = (taskSid: string, worker: string, channel: string = 'channel') => {
+  tasks.push({
+    sid: taskSid,
+    taskChannelUniqueName: channel,
+    attributes: `{"channelSid":"${channel}"}`,
+    fetch: async () => tasks.find(t => t.sid === taskSid),
+    update: async ({
+      attributes,
+      assignmentStatus,
+      reason,
+    }: {
+      attributes: string;
+      assignmentStatus: string;
+      reason: string;
+    }) => {
+      const task = tasks.find(t => t.sid === taskSid);
+      tasks = tasks.map(t => {
+        if (t.sid === task.sid)
+          return {
+            ...task,
+            attributes: attributes || task.attributes,
+            assignmentStatus: assignmentStatus || task.assignmentStatus,
+            reason: reason || task.reason,
+          };
+        return t;
+      });
+
+      return task;
+    },
+  });
+
+  if (channels[channel] === undefined) channels[channel] = [worker];
+  else channels[channel].push(worker);
+};
+
+const workspaces: { [x: string]: any } = {
+  WSxxx: {
+    tasks: (taskSid: string) => {
+      const task = tasks.find(t => t.sid === taskSid);
+      if (task) return task;
+
+      throw new Error('Task does not exists');
+    },
+  },
+};
+
+const baseContext = {
+  getTwilioClient: (): any => ({
+    taskrouter: {
+      workspaces: (workspaceSID: string) => {
+        if (workspaces[workspaceSID]) return workspaces[workspaceSID];
+
+        throw new Error('Workspace does not exists');
+      },
+    },
+    chat: {
+      services: (serviceSid: string) => {
+        if (serviceSid === baseContext.CHAT_SERVICE_SID)
+          return {
+            channels: (channelSid: string) => {
+              if (channels[channelSid])
+                return {
+                  members: (memberSid: string) => {
+                    if (channels[channelSid].includes(memberSid))
+                      return {
+                        remove: async () => {
+                          channels[channelSid] = channels[channelSid].filter(v => v !== memberSid);
+                        },
+                      };
+
+                    throw new Error('Member is not participant');
+                  },
+                };
+
+              throw new Error('Error retrieving chat channel');
+            },
+          };
+
+        throw new Error('Error retrieving chat service');
+      },
+    },
+  }),
+  DOMAIN_NAME: 'serverless',
+  TWILIO_WORKSPACE_SID: 'WSxxx',
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: 'WWxxx',
+  CHAT_SERVICE_SID: 'ISxxx',
+};
+
+describe('transferChatResolve', () => {
+  beforeAll(() => {
+    helpers.setup({});
+  });
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  beforeEach(() => {
+    tasks = [];
+    channels.channel = [];
+    createTask('task1', 'worker1');
+    createTask('task2', 'worker2');
+  });
+
+  test('Should return status 400', async () => {
+    const event1: Body = {
+      closeSid: undefined,
+      keepSid: 'task2',
+      kickMember: 'worker1',
+      newStatus: 'completed',
+    };
+    const event2: Body = {
+      closeSid: 'task1',
+      keepSid: undefined,
+      kickMember: 'worker1',
+      newStatus: 'completed',
+    };
+    const event3: Body = {
+      closeSid: 'task1',
+      keepSid: 'task2',
+      kickMember: undefined,
+      newStatus: 'completed',
+    };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(400);
+    };
+
+    await Promise.all(
+      [{}, event1, event2, event3].map(event => transferChatResolve(baseContext, event, callback)),
+    );
+  });
+
+  test('Should return status 500', async () => {
+    const event1: Body = {
+      closeSid: 'non existing',
+      keepSid: 'task2',
+      kickMember: '',
+      newStatus: 'completed',
+    };
+    const event2: Body = {
+      closeSid: 'task1',
+      keepSid: 'non existing',
+      kickMember: '',
+      newStatus: 'completed',
+    };
+
+    const callback1: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Workspace does not exists');
+    };
+
+    const callback2: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Task does not exists');
+    };
+
+    const { getTwilioClient, DOMAIN_NAME } = baseContext;
+    await transferChatResolve({ getTwilioClient, DOMAIN_NAME }, event1, callback1);
+    await transferChatResolve(baseContext, event1, callback2);
+    await transferChatResolve(baseContext, event2, callback2);
+  });
+
+  test('Should return status 200 (close original)', async () => {
+    const event: Body = {
+      closeSid: 'task1',
+      keepSid: 'task2',
+      kickMember: 'worker1',
+      newStatus: 'completed',
+    };
+
+    const expected = { closed: 'task1', kept: 'task2' };
+    const expectedClosedAttr = JSON.stringify({
+      channelSid: 'CH00000000000000000000000000000000',
+      proxySessionSID: 'KC00000000000000000000000000000000',
+      transferMeta: { transferStatus: 'completed' },
+    });
+    const expectedKeptAttr = JSON.stringify({
+      channelSid: 'channel',
+      transferMeta: { transferStatus: 'completed' },
+    });
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(response.getBody()).toStrictEqual(expected);
+
+      const { closed, kept } = response.getBody();
+      const closedTask = tasks.find(t => t.sid === closed);
+      const keptTask = tasks.find(t => t.sid === kept);
+
+      expect(closedTask.assignmentStatus).toBe('completed');
+      expect(closedTask.reason).toBe('task transferred');
+      expect(closedTask.attributes).toBe(expectedClosedAttr);
+      expect(keptTask.attributes).toBe(expectedKeptAttr);
+    };
+
+    await transferChatResolve(baseContext, event, callback);
+  });
+
+  test('Should return status 200 (close transferred)', async () => {
+    const event: Body = {
+      closeSid: 'task2',
+      keepSid: 'task1',
+      kickMember: 'worker1',
+      newStatus: 'completed',
+    };
+
+    const expected = { closed: 'task2', kept: 'task1' };
+    const expectedClosedAttr = JSON.stringify({
+      channelSid: 'CH00000000000000000000000000000000',
+      proxySessionSID: 'KC00000000000000000000000000000000',
+      transferMeta: { transferStatus: 'completed' },
+    });
+    const expectedKeptAttr = JSON.stringify({
+      channelSid: 'channel',
+      transferMeta: { transferStatus: 'completed' },
+    });
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(response.getBody()).toStrictEqual(expected);
+
+      const { closed, kept } = response.getBody();
+      const closedTask = tasks.find(t => t.sid === closed);
+      const keptTask = tasks.find(t => t.sid === kept);
+
+      expect(closedTask.assignmentStatus).toBe('completed');
+      expect(closedTask.reason).toBe('task transferred');
+      expect(closedTask.attributes).toBe(expectedClosedAttr);
+      expect(keptTask.attributes).toBe(expectedKeptAttr);
+    };
+
+    await transferChatResolve(baseContext, event, callback);
+  });
+});

--- a/tests/transferChatStart.test.ts
+++ b/tests/transferChatStart.test.ts
@@ -1,0 +1,224 @@
+import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { handler as transferChatStart, Body } from '../functions/transferChatStart';
+
+import helpers, { MockedResponse } from './helpers';
+
+let tasks: any[] = [
+  {
+    sid: 'task1',
+    taskChannelUniqueName: 'channel',
+    attributes: '{}',
+    fetch: async () => tasks.find(t => t.sid === 'task1'),
+    update: async ({
+      attributes,
+      assignmentStatus,
+      reason,
+    }: {
+      attributes: string;
+      assignmentStatus: string;
+      reason: string;
+    }) => {
+      const task = tasks.find(t => t.sid === 'task1');
+      tasks = tasks.map(t => {
+        if (t.sid === task.sid)
+          return {
+            ...task,
+            attributes: attributes || task.attributes,
+            assignmentStatus: assignmentStatus || task.assignmentStatus,
+            reason: reason || task.reason,
+          };
+        return t;
+      });
+
+      return task;
+    },
+  },
+];
+
+const workspaces: { [x: string]: any } = {
+  WSxxx: {
+    tasks: (taskSid: string) => {
+      const task = tasks.find(t => t.sid === taskSid);
+      if (task) return task;
+
+      throw new Error('Task does not exists');
+    },
+  },
+};
+
+workspaces.WSxxx.tasks.create = async (options: any) => {
+  const newTask = {
+    ...options,
+    sid: 'newTaskSid',
+  };
+  tasks.push(newTask);
+  return newTask;
+};
+
+const baseContext = {
+  getTwilioClient: (): any => ({
+    taskrouter: {
+      workspaces: (workspaceSID: string) => {
+        if (workspaces[workspaceSID]) return workspaces[workspaceSID];
+
+        throw new Error('Workspace does not exists');
+      },
+    },
+  }),
+  DOMAIN_NAME: 'serverless',
+  TWILIO_WORKSPACE_SID: 'WSxxx',
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: 'WWxxx',
+};
+
+describe('transferChatStart', () => {
+  beforeAll(() => {
+    helpers.setup({});
+  });
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  afterEach(() => {
+    if (tasks.length > 1) tasks = tasks.slice(0, 1);
+  });
+
+  test('Should return status 400', async () => {
+    const event1: Body = {
+      taskSid: undefined,
+      targetSid: 'WKxxx',
+      workerName: 'worker1',
+      mode: 'COLD',
+    };
+    const event2: Body = {
+      taskSid: 'task1',
+      targetSid: undefined,
+      workerName: 'worker1',
+      mode: 'COLD',
+    };
+    const event3: Body = {
+      taskSid: 'task1',
+      targetSid: 'WKxxx',
+      workerName: undefined,
+      mode: 'COLD',
+    };
+    const event4: Body = {
+      taskSid: 'task1',
+      targetSid: 'WKxxx',
+      workerName: 'worker1',
+      mode: undefined,
+    };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(400);
+    };
+
+    await Promise.all(
+      [{}, event1, event2, event3, event4].map(event =>
+        transferChatStart(baseContext, event, callback),
+      ),
+    );
+  });
+
+  test('Should return status 500', async () => {
+    const event1: Body = {
+      taskSid: 'task1',
+      targetSid: 'WKxxx',
+      workerName: 'worker1',
+      mode: 'COLD',
+    };
+
+    const event2: Body = {
+      taskSid: 'non existing',
+      targetSid: 'WKxxx',
+      workerName: 'worker1',
+      mode: 'COLD',
+    };
+
+    const callback1: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Workspace does not exists');
+    };
+
+    const callback2: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Task does not exists');
+    };
+
+    const { getTwilioClient, DOMAIN_NAME } = baseContext;
+    await transferChatStart({ getTwilioClient, DOMAIN_NAME }, event1, callback1);
+    await transferChatStart(baseContext, event2, callback2);
+  });
+
+  test('Should return status 200 (WARM)', async () => {
+    const event: Body = {
+      taskSid: 'task1',
+      targetSid: 'WKxxx',
+      workerName: 'worker1',
+      mode: 'WARM',
+    };
+    const before = Array.from(tasks);
+    const expected = { taskSid: 'newTaskSid' };
+
+    const callback: ServerlessCallback = (err, result) => {
+      const originalTask = tasks.find(t => t.sid === 'task1');
+      const newTask = tasks.find(t => t.sid === 'newTaskSid');
+
+      const expectedNewAttr =
+        '{"conversations":{"conversation_id":"task1"},"ignoreAgent":"worker1","targetSid":"WKxxx","transferTargetType":"worker"}';
+
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(response.getBody()).toStrictEqual(expected);
+      expect(originalTask).toStrictEqual(before[0]);
+      expect(tasks).toHaveLength(2);
+      expect(newTask).toHaveProperty('sid');
+      expect(newTask.taskChannel).toBe(originalTask.taskChannelUniqueName);
+      expect(newTask.wokflowSid).toBe(originalTask.wokflowSid);
+      expect(newTask.attributes).toBe(expectedNewAttr);
+    };
+
+    await transferChatStart(baseContext, event, callback);
+  });
+
+  test('Should return status 200 (COLD)', async () => {
+    const event: Body = {
+      taskSid: 'task1',
+      targetSid: 'WKxxx',
+      workerName: 'worker1',
+      mode: 'COLD',
+    };
+    const expectedOldAttr =
+      '{"channelSid":"CH00000000000000000000000000000000","proxySessionSID":"KC00000000000000000000000000000000"}';
+    const expectedNewAttr =
+      '{"conversations":{"conversation_id":"task1"},"ignoreAgent":"worker1","targetSid":"WKxxx","transferTargetType":"worker"}';
+
+    const expected = { taskSid: 'newTaskSid' };
+
+    const callback: ServerlessCallback = (err, result) => {
+      const originalTask = tasks.find(t => t.sid === 'task1');
+      const newTask = tasks.find(t => t.sid === 'newTaskSid');
+
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(response.getBody()).toStrictEqual(expected);
+      expect(originalTask.attributes).toBe(expectedOldAttr);
+      expect(originalTask.reason).toBe('task transferred');
+      expect(originalTask.assignmentStatus).toBe('completed');
+      expect(tasks).toHaveLength(2);
+      expect(newTask).toHaveProperty('sid');
+      expect(newTask.taskChannel).toBe(originalTask.taskChannelUniqueName);
+      expect(newTask.wokflowSid).toBe(originalTask.wokflowSid);
+      expect(newTask.attributes).toBe(expectedNewAttr);
+    };
+
+    await transferChatStart(baseContext, event, callback);
+  });
+});


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-141
This PR is related to https://github.com/tech-matters/flex-plugins/pull/101

Added two new functions: 
- `transferChatStart`: from the task being transferred, creates a new task with the same channel as the former one, and closes the original if the transfer mode is `cold`
- `transferChatResolve`: used only for `warm` transfers, closes one task, leaves the other one open and kicks the counselor that is not required anymore