### PR TITLE
Added a function that pre-process chat tasks

### DIFF
--- a/functions/autopilotRedirect.protected.ts
+++ b/functions/autopilotRedirect.protected.ts
@@ -62,11 +62,16 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
   event: Event,
   callback: ServerlessCallback,
 ) => {
-  if (event.Channel === 'chat' && event.CurrentTask === 'redirect_function')
-    await handleChatChannel(context, event);
+  try {
+    if (event.Channel === 'chat' && event.CurrentTask === 'redirect_function')
+      await handleChatChannel(context, event);
 
-  const actions = buildActionsArray(context, event);
-  const returnObj = { actions };
+    const actions = buildActionsArray(context, event);
+    const returnObj = { actions };
 
-  callback(null, returnObj);
+    callback(null, returnObj);
+  } catch (err) {
+    // If something goes wrong, just handoff to counselor so contact is not lost
+    callback(null, { actions: [{ redirect: 'task://counselor_handoff' }] });
+  }
 };

--- a/functions/autopilotRedirect.protected.ts
+++ b/functions/autopilotRedirect.protected.ts
@@ -5,8 +5,9 @@ import {
 } from '@twilio-labs/serverless-runtime-types/types';
 
 export interface Event {
-  Memory: string;
   Channel: string;
+  CurrentTask: string;
+  Memory: string;
   UserIdentifier: string;
 }
 
@@ -87,7 +88,9 @@ export const handler: ServerlessFunctionSignature<EnvVars, Event> = async (
   event: Event,
   callback: ServerlessCallback,
 ) => {
-  if (event.Channel === 'chat') await handleChatChannel(context, event);
+  if (event.Channel === 'chat' && event.CurrentTask === 'redirect_function')
+    await handleChatChannel(context, event);
+
   const actions = buildActionsArray(context, event);
   const returnObj = { actions };
 

--- a/functions/autopilotRedirect.protected.ts
+++ b/functions/autopilotRedirect.protected.ts
@@ -1,40 +1,57 @@
 import { Context, ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
-import { JsonObject } from 'swagger-ui-express';
 
 export interface Event {
   Memory: string;
+  Channel: string;
 }
 
-export const handler = (context: Context, event: Event, callback: ServerlessCallback) => {
-  const memory = JSON.parse(event.Memory);
-  const returnObj: JsonObject = { actions: [] };
+type EnvVars = {
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: string;
+};
 
+const buildActionsArray = (context: Context<EnvVars>, event: Event) => {
+  const memory = JSON.parse(event.Memory);
   switch (memory.at) {
-    case 'survey':
-    case 'gender_why':
-      // eslint-disable-next-line no-case-declarations
+    case 'survey': {
+      if (event.Channel === 'voice') {
+        const say = { say: 'Hold on, we are connecting you with an agent' };
+        const handoff = {
+          handoff: {
+            channel: 'voice',
+            uri: `taskrouter://${context.TWILIO_CHAT_TRANSFER_WORKFLOW_SID}`,
+          },
+        };
+        return [say, handoff];
+      }
+
+      const redirect = { redirect: 'task://counselor_handoff' };
+      return [redirect];
+    }
+    case 'gender_why': {
       const { gender } = memory.twilio.collected_data.collect_survey.answers;
 
       // Handle someone asking "why" or questioning what is meant by gender
       // Answers to the "why" question will never produce this
       if (gender.error === undefined && gender.answer.toLowerCase() === 'why') {
-        returnObj.actions.push({
-          redirect: 'task://gender_why',
-        });
-        break;
+        const redirect = { redirect: 'task://gender_why' };
+        return [redirect];
       }
 
-      returnObj.actions.push({
-        redirect: 'task://counselor_handoff',
-      });
-      break;
-    default:
+      const redirect = { redirect: 'task://counselor_handoff' };
+      return [redirect];
+    }
+    default: {
       // If we ever get here, it's in error
       // Just handoff to counselor for now, maybe need to internally record an error
-      returnObj.actions.push({
-        redirect: 'task://counselor_handoff',
-      });
-      break;
+      const redirect = { redirect: 'task://counselor_handoff' };
+      return [redirect];
+    }
   }
+};
+
+export const handler = (context: Context<EnvVars>, event: Event, callback: ServerlessCallback) => {
+  const actions = buildActionsArray(context, event);
+  const returnObj = { actions };
+
   callback(null, returnObj);
 };

--- a/functions/autopilotRedirect.protected.ts
+++ b/functions/autopilotRedirect.protected.ts
@@ -47,30 +47,6 @@ const buildActionsArray = (context: Context<EnvVars>, event: Event) => {
 
   switch (memory.at) {
     case 'survey': {
-      if (event.Channel === 'voice') {
-        const say = { say: 'Hold on, we are connecting you with an agent' };
-        const handoff = {
-          handoff: {
-            channel: 'voice',
-            uri: `taskrouter://${context.TWILIO_CHAT_TRANSFER_WORKFLOW_SID}`,
-          },
-        };
-        return [say, handoff];
-      }
-
-      const redirect = { redirect: 'task://counselor_handoff' };
-      return [redirect];
-    }
-    case 'gender_why': {
-      const { gender } = memory.twilio.collected_data.collect_survey.answers;
-
-      // Handle someone asking "why" or questioning what is meant by gender
-      // Answers to the "why" question will never produce this
-      if (gender.error === undefined && gender.answer.toLowerCase() === 'why') {
-        const redirect = { redirect: 'task://gender_why' };
-        return [redirect];
-      }
-
       const redirect = { redirect: 'task://counselor_handoff' };
       return [redirect];
     }

--- a/functions/autopilotRedirect.protected.ts
+++ b/functions/autopilotRedirect.protected.ts
@@ -11,9 +11,7 @@ export interface Event {
   UserIdentifier: string;
 }
 
-type EnvVars = {
-  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: string;
-};
+type EnvVars = {};
 
 const handleChatChannel = async (context: Context<EnvVars>, event: Event) => {
   const memory = JSON.parse(event.Memory);

--- a/tests/autopilotRedirect.test.ts
+++ b/tests/autopilotRedirect.test.ts
@@ -3,8 +3,39 @@ import { handler as autopilotRedirect, Event } from '../functions/autopilotRedir
 
 import helpers from './helpers';
 
+const users: { [u: string]: any } = {
+  user: {
+    attributes: '{}',
+    update: async (attributes: string) => {
+      users.user = attributes;
+    },
+  },
+};
+
 const baseContext = {
-  getTwilioClient: (): any => ({}),
+  getTwilioClient: (): any => ({
+    chat: {
+      services: (serviceSid: string) => ({
+        channels: (channelSid: string) => {
+          if (channelSid === 'web')
+            return {
+              fetch: async () => ({
+                attributes: '{"channel_type": "web"}',
+              }),
+            };
+
+          return {
+            fetch: async () => ({
+              attributes: '{}',
+            }),
+          };
+        },
+        users: (user: string) => ({
+          fetch: async () => users[user],
+        }),
+      }),
+    },
+  }),
   DOMAIN_NAME: 'serverless',
 };
 
@@ -16,10 +47,14 @@ describe('Redirect forwards to the correct task', () => {
     helpers.teardown();
   });
 
-  test('Should forward normal surveys to a counselor', () => {
+  test('Should forward normal surveys to a counselor (NO update to user as channel is not web)', async () => {
     const event: Event = {
+      Channel: 'chat',
+      CurrentTask: 'redirect_function',
+      UserIdentifier: 'user',
       Memory: `{
                 "twilio": {
+                  "chat": { "ChannelSid": "not web" },
                     "collected_data": {
                         "collect_survey": {
                             "answers": {
@@ -41,17 +76,23 @@ describe('Redirect forwards to the correct task', () => {
     };
 
     const callback: ServerlessCallback = (err, result) => {
+      const expectedAttr = {};
       expect(result).toMatchObject({ actions: [{ redirect: 'task://counselor_handoff' }] });
       expect(err).toBeNull();
+      expect(users.user.attributes).toBe(JSON.stringify(expectedAttr));
     };
 
-    expect(autopilotRedirect(baseContext, event, callback));
+    await autopilotRedirect(baseContext, event, callback);
   });
 
-  test('Should forward the Why gender to the answer', () => {
+  test('Should forward normal surveys to a counselor (YES update to user as channel is web)', async () => {
     const event: Event = {
+      Channel: 'chat',
+      CurrentTask: 'redirect_function',
+      UserIdentifier: 'user',
       Memory: `{
                 "twilio": {
+                    "chat": { "ChannelSid": "web" },
                     "collected_data": {
                         "collect_survey": {
                             "answers": {
@@ -62,7 +103,7 @@ describe('Redirect forwards to the correct task', () => {
                                     "answer": "12"
                                 },
                                 "gender": {
-                                    "answer": "why"
+                                    "answer": "Girl"
                                 }
                             }
                         }
@@ -73,78 +114,13 @@ describe('Redirect forwards to the correct task', () => {
     };
 
     const callback: ServerlessCallback = (err, result) => {
-      expect(result).toMatchObject({ actions: [{ redirect: 'task://gender_why' }] });
-      expect(err).toBeNull();
-    };
+      const expectedAttr = { lockInput: true };
 
-    expect(autopilotRedirect(baseContext, event, callback));
-  });
-
-  test('Should forward all regular gender_why responses to a counselor', () => {
-    const event: Event = {
-      Memory: `{
-                  "twilio": {
-                      "collected_data": {
-                          "collect_survey": {
-                              "answers": {
-                                  "about_self": {
-                                      "answer": "No"
-                                  },
-                                  "age": {
-                                      "answer": "23"
-                                  },
-                                  "gender": {
-                                      "answer": "Boy"
-                                  }
-                              }
-                          }
-                      }
-                  },
-                  "at": "gender_why"
-              }`,
-    };
-
-    const callback: ServerlessCallback = (err, result) => {
       expect(result).toMatchObject({ actions: [{ redirect: 'task://counselor_handoff' }] });
       expect(err).toBeNull();
+      expect(users.user.attributes).toBe(JSON.stringify(expectedAttr));
     };
 
-    expect(autopilotRedirect(baseContext, event, callback));
-  });
-
-  test('Should forward non-responses to why, even with autopilot weirdness, to a counselor', () => {
-    const event: Event = {
-      Memory: `{
-                "twilio": {
-                    "collected_data": {
-                        "collect_survey": {
-                            "answers": {
-                                "about_self": {
-                                    "answer": "Yes"
-                                },
-                                "age": {
-                                    "answer": "12"
-                                },
-                                "gender": {
-                                    "answer": "why",
-                                    "error": {
-                                      "message": "Invalid Value",
-                                      "value": "prefer not to answer"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "at": "gender_why"
-            }`,
-    };
-
-    const callback: ServerlessCallback = (err, result) => {
-      expect(result).toMatchObject({ actions: [{ redirect: 'task://counselor_handoff' }] });
-      expect(err).toBeNull();
-    };
-
-    expect(autopilotRedirect(baseContext, event, callback));
+    await autopilotRedirect(baseContext, event, callback);
   });
 });

--- a/tests/autopilotRedirect.test.ts
+++ b/tests/autopilotRedirect.test.ts
@@ -15,6 +15,7 @@ const users: { [u: string]: any } = {
 const baseContext = {
   getTwilioClient: (): any => ({
     chat: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       services: (serviceSid: string) => ({
         channels: (channelSid: string) => {
           if (channelSid === 'web')


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-249
This PR is related to https://github.com/tech-matters/webchat/pull/9

Adds a new attribute (`lockInput`) to the user resource. That attribute is used in webchat to hide the input (maybe the naming is wrong). The webchat is in charge of changing the value of `lockInput` once a counselor joins, using channel events.

Useful docs:
https://www.twilio.com/docs/chat/rest/user-resourcehttps://media.twiliocdn.com/sdk/js/chat/releases/3.2.3/docs/User.html#updateAttributes__anchor
