### PR TITLE
Continue to support transfers with manual pull

### DIFF
--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -34,6 +34,8 @@ export const adjustChatCapacity = async (
     .workers(body.workerSid)
     .fetch();
 
+  if (!worker) return { status: 404, message: 'Could not find worker.' };
+
   const { maxMessageCapacity } = JSON.parse(worker.attributes);
 
   const channels = await worker.workerChannels().list();

--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -14,33 +14,38 @@ import {
 
 const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 
-type EnvVars = {};
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+};
 
 export type Body = {
   workerSid?: string;
-  workspaceSid?: string;
-  channelSid?: string;
-  workerLimit?: number;
   adjustment?: 'increase' | 'decrease';
 };
 
-const adjustChatCapacity = async (
+export const adjustChatCapacity = async (
   context: Context<EnvVars>,
   body: Required<Body>,
 ): Promise<{ status: number; message: string }> => {
   const client = context.getTwilioClient();
 
-  const channel = await client.taskrouter
-    .workspaces(body.workspaceSid)
+  const worker = await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
     .workers(body.workerSid)
-    .workerChannels(body.channelSid)
     .fetch();
+
+  const { maxMessageCapacity } = JSON.parse(worker.attributes);
+
+  const channels = await worker.workerChannels().list();
+  const channel = channels.find(c => c.taskChannelUniqueName === 'chat');
+
+  if (!channel) return { status: 404, message: 'Could not find chat channel.' };
 
   if (body.adjustment === 'increase') {
     if (channel.availableCapacityPercentage > 0)
       return { status: 412, message: 'Still have available capacity, no need to increase.' };
 
-    if (!(channel.configuredCapacity < body.workerLimit))
+    if (!(channel.configuredCapacity < maxMessageCapacity))
       return { status: 412, message: 'Reached the max capacity.' };
 
     await channel.update({ capacity: channel.configuredCapacity + 1 });
@@ -63,16 +68,13 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
     const response = responseWithCors();
     const resolve = bindResolve(callback)(response);
 
-    const { workerSid, workspaceSid, channelSid, workerLimit, adjustment } = event;
+    const { workerSid, adjustment } = event;
 
     try {
       if (workerSid === undefined) return resolve(error400('workerSid'));
-      if (workspaceSid === undefined) return resolve(error400('workspaceSid'));
-      if (channelSid === undefined) return resolve(error400('channelSid'));
-      if (workerLimit === undefined) return resolve(error400('workerLimit'));
       if (adjustment === undefined) return resolve(error400('adjustment'));
 
-      const validBody = { workerSid, workspaceSid, channelSid, workerLimit, adjustment };
+      const validBody = { workerSid, adjustment };
 
       const { status, message } = await adjustChatCapacity(context, validBody);
 

--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -65,6 +65,8 @@ export const adjustChatCapacity = async (
   return { status: 400, message: 'Invalid adjustment argument' };
 };
 
+export type AdjustChatCapacityType = typeof adjustChatCapacity;
+
 export const handler: ServerlessFunctionSignature = TokenValidator(
   async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
     const response = responseWithCors();

--- a/functions/adjustChatCapacity.ts
+++ b/functions/adjustChatCapacity.ts
@@ -38,6 +38,12 @@ export const adjustChatCapacity = async (
 
   const { maxMessageCapacity } = JSON.parse(worker.attributes);
 
+  if (!maxMessageCapacity)
+    return {
+      status: 409,
+      message: `Worker ${body.workerSid} does not have a "maxMessageCapacity" attribute, can't adjust capacity.`,
+    };
+
   const channels = await worker.workerChannels().list();
   const channel = channels.find(c => c.taskChannelUniqueName === 'chat');
 

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -133,11 +133,14 @@ async function validateChannelIfWorker(
   const workerAttr = JSON.parse(worker.attributes);
 
   const unavailableVoice = channelType === 'voice' && !workerChannel.availableCapacityPercentage;
+  // if maxMessageCapacity is not set, just use configuredCapacity without adjustChatCapacity
   const unavailableChat =
-    channelType !== 'voice' &&
+    workerAttr.maxMessageCapacity 
+      ? channelType !== 'voice' &&
     !workerChannel.availableCapacityPercentage &&
     workerAttr.maxMessageCapacity &&
-    workerChannel.configuredCapacity >= workerAttr.maxMessageCapacity;
+    workerChannel.configuredCapacity >= workerAttr.maxMessageCapacity
+      : channelType !== 'voice' && !workerChannel.availableCapacityPercentage;
 
   if (unavailableVoice || unavailableChat)
     return {
@@ -146,9 +149,9 @@ async function validateChannelIfWorker(
     } as const;
 
   const shouldIncrease =
+    workerAttr.maxMessageCapacity &&
     channelType !== 'voice' &&
     !workerChannel.availableCapacityPercentage &&
-    workerAttr.maxMessageCapacity &&
     workerChannel.configuredCapacity < workerAttr.maxMessageCapacity;
 
   return { type: 'worker', worker, shouldIncrease } as const;

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -15,6 +15,8 @@ import {
   error500,
   success,
 } from '@tech-matters/serverless-helpers';
+// eslint-disable-next-line prettier/prettier
+import type { AdjustChatCapacityType } from './adjustChatCapacity';
 
 const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 
@@ -159,7 +161,8 @@ async function increaseChatCapacity(
   // once created the task, increase worker chat capacity if needed
   if (validationResult.shouldIncrease) {
     const { path } = Runtime.getFunctions().adjustChatCapacity;
-    const { adjustChatCapacity } = require(path) as typeof import('./adjustChatCapacity');
+    // eslint-disable-next-line prefer-destructuring
+    const adjustChatCapacity: AdjustChatCapacityType = require(path).adjustChatCapacity;
 
     const { worker } = validationResult;
 

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -223,7 +223,7 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
 
       if (validationResult.type === 'error') {
         const { status, message } = validationResult.payload;
-        resolve(send(status)(message));
+        resolve(send(status)({ status, message }));
         return;
       }
 

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -1,14 +1,17 @@
+/* eslint-disable import/no-dynamic-require */
+/* eslint-disable global-require */
 import '@twilio-labs/serverless-runtime-types';
 import {
   Context,
   ServerlessCallback,
   ServerlessFunctionSignature,
 } from '@twilio-labs/serverless-runtime-types/types';
+import { PromiseValue } from 'type-fest';
 import {
   responseWithCors,
   bindResolve,
   error400,
-  error403,
+  send,
   error500,
   success,
 } from '@tech-matters/serverless-helpers';
@@ -75,6 +78,8 @@ async function kickMember(context: Context<EnvVars>, memberToKick: string, chatC
 }
 
 async function closeTaskAndKick(context: Context<EnvVars>, body: Required<Body>) {
+  if (body.mode !== 'COLD') return null;
+
   const client = context.getTwilioClient();
 
   // retrieve attributes of the task to close
@@ -91,6 +96,80 @@ async function closeTaskAndKick(context: Context<EnvVars>, body: Required<Body>)
   ]);
 
   return closedTask;
+}
+
+// if transfer targets a worker, validates that it can be effectively transferred, and if the worker's chat capacity needs to increase
+async function validateChannelIfWorker(
+  context: Context<EnvVars>,
+  targetSid: string,
+  transferTargetType: string,
+  taskChannelUniqueName: string,
+  channelType: string,
+) {
+  if (transferTargetType === 'queue') return { type: 'queue' } as const;
+
+  const client = context.getTwilioClient();
+
+  const [worker, workerChannel] = await Promise.all([
+    client.taskrouter
+      .workspaces(context.TWILIO_WORKSPACE_SID)
+      .workers(targetSid)
+      .fetch(),
+    client.taskrouter
+      .workspaces(context.TWILIO_WORKSPACE_SID)
+      .workers(targetSid)
+      .workerChannels(taskChannelUniqueName)
+      .fetch(),
+  ]);
+
+  if (!worker.available)
+    return {
+      type: 'error',
+      payload: { status: 403, message: "Error: can't transfer to an offline counselor" },
+    } as const;
+
+  const workerAttr = JSON.parse(worker.attributes);
+
+  const unavailableVoice = channelType === 'voice' && !workerChannel.availableCapacityPercentage;
+  const unavailableChat =
+    channelType !== 'voice' &&
+    !workerChannel.availableCapacityPercentage &&
+    workerAttr.maxMessageCapacity &&
+    workerChannel.configuredCapacity >= workerAttr.maxMessageCapacity;
+
+  if (unavailableVoice || unavailableChat)
+    return {
+      type: 'error',
+      payload: { status: 403, message: 'Error: counselor has no available capacity' },
+    } as const;
+
+  const shouldIncrease =
+    channelType !== 'voice' &&
+    !workerChannel.availableCapacityPercentage &&
+    workerAttr.maxMessageCapacity &&
+    workerChannel.configuredCapacity < workerAttr.maxMessageCapacity;
+
+  return { type: 'worker', worker, shouldIncrease } as const;
+}
+
+async function increaseChatCapacity(
+  context: Context<EnvVars>,
+  validationResult: PromiseValue<ReturnType<typeof validateChannelIfWorker>>,
+) {
+  // once created the task, increase worker chat capacity if needed
+  if (validationResult.shouldIncrease) {
+    const { path } = Runtime.getFunctions().adjustChatCapacity;
+    const { adjustChatCapacity } = require(path) as typeof import('./adjustChatCapacity');
+
+    const { worker } = validationResult;
+
+    const body = {
+      workerSid: worker.sid,
+      adjustment: 'increase',
+    } as const;
+
+    await adjustChatCapacity(context, body);
+  }
 }
 
 export const handler: ServerlessFunctionSignature = TokenValidator(
@@ -130,33 +209,23 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
         .tasks(taskSid)
         .fetch();
 
+      const originalAttributes = JSON.parse(originalTask.attributes);
+
       const transferTargetType = targetSid.startsWith('WK') ? 'worker' : 'queue';
 
-      if (transferTargetType === 'worker') {
-        const [worker, workerChannel] = await Promise.all([
-          client.taskrouter
-            .workspaces(context.TWILIO_WORKSPACE_SID)
-            .workers(targetSid)
-            .fetch(),
-          client.taskrouter
-            .workspaces(context.TWILIO_WORKSPACE_SID)
-            .workers(targetSid)
-            .workerChannels(originalTask.taskChannelUniqueName)
-            .fetch(),
-        ]);
+      const validationResult = await validateChannelIfWorker(
+        context,
+        targetSid,
+        transferTargetType,
+        originalTask.taskChannelUniqueName,
+        originalAttributes.channelType,
+      );
 
-        if (!worker.available) {
-          resolve(error403("Error: can't transfer to an offline counselor"));
-          return;
-        }
-
-        if (!workerChannel.availableCapacityPercentage) {
-          resolve(error403('Error: counselor has no available capacity'));
-          return;
-        }
+      if (validationResult.type === 'error') {
+        const { status, message } = validationResult.payload;
+        resolve(send(status)(message));
+        return;
       }
-
-      const originalAttributes = JSON.parse(originalTask.attributes);
 
       const newAttributes = {
         ...originalAttributes,
@@ -175,12 +244,14 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
           workflowSid: context.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
           taskChannel: originalTask.taskChannelUniqueName,
           attributes: JSON.stringify(newAttributes),
+          priority: 100,
         });
 
-      if (mode === 'COLD') {
-        const validBody = { taskSid, targetSid, ignoreAgent, mode, memberToKick };
-        await closeTaskAndKick(context, validBody);
-      }
+      // Final actions that might not happen (conditions specified inside of each)
+      await Promise.all([
+        increaseChatCapacity(context, validationResult),
+        closeTaskAndKick(context, { mode, ignoreAgent, memberToKick, targetSid, taskSid }),
+      ]);
 
       resolve(success({ taskSid: newTask.sid }));
     } catch (err) {

--- a/functions/transferChatStart.ts
+++ b/functions/transferChatStart.ts
@@ -138,7 +138,6 @@ async function validateChannelIfWorker(
     workerAttr.maxMessageCapacity 
       ? channelType !== 'voice' &&
     !workerChannel.availableCapacityPercentage &&
-    workerAttr.maxMessageCapacity &&
     workerChannel.configuredCapacity >= workerAttr.maxMessageCapacity
       : channelType !== 'voice' && !workerChannel.availableCapacityPercentage;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20101,8 +20101,7 @@
     "type-fest": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.17.0.tgz",
-      "integrity": "sha512-EFi9HE4hHj85XnVV80uAUMgICQmhxYgiEvtmfpcD6jqn6zYr36HxAU6k+i/DSY28TK7/lYL0s4v/kWmiKdqaoA==",
-      "dev": true
+      "integrity": "sha512-EFi9HE4hHj85XnVV80uAUMgICQmhxYgiEvtmfpcD6jqn6zYr36HxAU6k+i/DSY28TK7/lYL0s4v/kWmiKdqaoA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20073,6 +20073,14 @@
         "window-size": "^1.1.1",
         "wrap-ansi": "^5.1.0",
         "yargs": "^13.2.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
       }
     },
     "type-check": {
@@ -20091,9 +20099,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.17.0.tgz",
+      "integrity": "sha512-EFi9HE4hHj85XnVV80uAUMgICQmhxYgiEvtmfpcD6jqn6zYr36HxAU6k+i/DSY28TK7/lYL0s4v/kWmiKdqaoA==",
       "dev": true
     },
     "type-is": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "redoc-cli": "^0.9.7",
     "ts-jest": "^26.0.0",
     "twilio-run": "2.* || >2.0.0-rc",
-    "type-fest": "^0.17.0",
     "typescript": "^3.8.3"
   },
   "engines": {
@@ -45,6 +44,7 @@
     "@tech-matters/serverless-helpers": "^1.0.6",
     "@twilio-labs/serverless-runtime-types": "^1.1.8",
     "swagger-ui-express": "^4.1.4",
-    "twilio-flex-token-validator": "^1.5.3"
+    "twilio-flex-token-validator": "^1.5.3",
+    "type-fest": "^0.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "redoc-cli": "^0.9.7",
     "ts-jest": "^26.0.0",
     "twilio-run": "2.* || >2.0.0-rc",
+    "type-fest": "^0.17.0",
     "typescript": "^3.8.3"
   },
   "engines": {

--- a/tests/adjustChatCapacity.test.ts
+++ b/tests/adjustChatCapacity.test.ts
@@ -4,6 +4,7 @@ import { handler as adjustChatCapacity, Body } from '../functions/adjustChatCapa
 import helpers, { MockedResponse } from './helpers';
 
 let workerChannel = {
+  taskChannelUniqueName: 'chat',
   configuredCapacity: 1,
   availableCapacityPercentage: 0,
   updateCapacityPercentage: (availableCapacityPercentage: number) => {
@@ -14,19 +15,36 @@ let workerChannel = {
   },
 };
 
+const someWorker = {
+  attributes: JSON.stringify({ maxMessageCapacity: 2 }),
+  fetch: async () => someWorker,
+  workerChannels: () => ({
+    list: async () => [workerChannel],
+    fetch: async () => workerChannel,
+  }),
+};
+
+const withoutChannel = {
+  attributes: JSON.stringify({ maxMessageCapacity: 2 }),
+  fetch: async () => withoutChannel,
+  workerChannels: () => ({
+    list: async () => [],
+  }),
+};
+
 const baseContext = {
   getTwilioClient: (): any => ({
     taskrouter: {
       workspaces: () => ({
-        workers: (workerSid: string) => ({
-          workerChannels: () => ({
-            fetch: async () => {
-              if (workerSid === 'worker123') return workerChannel;
+        workers: (workerSid: string) => {
+          if (workerSid === 'worker123') return someWorker;
 
-              throw new Error('Non existing worker');
-            },
-          }),
-        }),
+          if (workerSid === 'nonExisting') return { fetch: async () => null };
+
+          if (workerSid === 'withoutChannel') return withoutChannel;
+
+          throw new Error('Non existing worker');
+        },
       }),
     },
   }),
@@ -43,17 +61,11 @@ describe('populateCounselors', () => {
 
   test('Should return status 400', async () => {
     const workerSid = 'worker123';
-    const workspaceSid = 'workspace123';
-    const channelSid = 'channel123';
-    const workerLimit = 2;
     // const adjustment = 'increase';
     const event1 = {};
     const event2 = { ...event1, workerSid };
-    const event3 = { ...event2, workspaceSid };
-    const event4 = { ...event3, channelSid };
-    const event5 = { ...event4, workerLimit };
 
-    const events = [{}, event1, event2, event3, event4, event5];
+    const events = [event1, event2];
 
     const callback: ServerlessCallback = (err, result) => {
       expect(result).toBeDefined();
@@ -67,9 +79,6 @@ describe('populateCounselors', () => {
   test('Should return status 500', async () => {
     const event: Body = {
       workerSid: 'non-existing',
-      workspaceSid: 'workspace123',
-      channelSid: 'channel123',
-      workerLimit: 2,
       adjustment: 'increase',
     };
 
@@ -86,9 +95,6 @@ describe('populateCounselors', () => {
   test('Should return status 200 (increase)', async () => {
     const event: Body = {
       workerSid: 'worker123',
-      workspaceSid: 'workspace123',
-      channelSid: 'channel123',
-      workerLimit: 2,
       adjustment: 'increase',
     };
 
@@ -108,9 +114,6 @@ describe('populateCounselors', () => {
 
     const event: Body = {
       workerSid: 'worker123',
-      workspaceSid: 'workspace123',
-      channelSid: 'channel123',
-      workerLimit: 2,
       adjustment: 'decrease',
     };
 
@@ -130,9 +133,6 @@ describe('populateCounselors', () => {
 
     const event: Body = {
       workerSid: 'worker123',
-      workspaceSid: 'workspace123',
-      channelSid: 'channel123',
-      workerLimit: 2,
       adjustment: 'decrease',
     };
 
@@ -152,9 +152,6 @@ describe('populateCounselors', () => {
 
     const event: Body = {
       workerSid: 'worker123',
-      workspaceSid: 'workspace123',
-      channelSid: 'channel123',
-      workerLimit: 2,
       adjustment: 'increase',
     };
 
@@ -176,9 +173,6 @@ describe('populateCounselors', () => {
 
     const event: Body = {
       workerSid: 'worker123',
-      workspaceSid: 'workspace123',
-      channelSid: 'channel123',
-      workerLimit: 2,
       adjustment: 'increase',
     };
 
@@ -190,6 +184,48 @@ describe('populateCounselors', () => {
       const response = result as MockedResponse;
       expect(response.getStatus()).toBe(412);
       expect(response.getBody().message).toContain('Reached the max capacity');
+    };
+
+    await adjustChatCapacity(baseContext, event, callback);
+  });
+
+  test('Should return status 404 (Could not find worker)', async () => {
+    workerChannel.updateCapacityPercentage(0);
+    expect(workerChannel.availableCapacityPercentage).toStrictEqual(0);
+
+    const event: Body = {
+      workerSid: 'nonExisting',
+      adjustment: 'increase',
+    };
+
+    await adjustChatCapacity(baseContext, event, () => {});
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(404);
+      expect(response.getBody().message).toContain('Could not find worker');
+    };
+
+    await adjustChatCapacity(baseContext, event, callback);
+  });
+
+  test('Should return status 404 (Could not find chat channel)', async () => {
+    workerChannel.updateCapacityPercentage(0);
+
+    const event: Body = {
+      workerSid: 'withoutChannel',
+      adjustment: 'increase',
+    };
+
+    await adjustChatCapacity(baseContext, event, () => {});
+    expect(workerChannel.configuredCapacity).toStrictEqual(2);
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(404);
+      expect(response.getBody().message).toContain('Could not find chat channel');
     };
 
     await adjustChatCapacity(baseContext, event, callback);

--- a/tests/transferChatStart.test.ts
+++ b/tests/transferChatStart.test.ts
@@ -66,6 +66,8 @@ let tasks: any[] = [
 
 const channels: { [x: string]: string[] } = {};
 
+const configurableCapacity = 1;
+
 const workspaces: { [x: string]: any } = {
   WSxxx: {
     tasks: (taskSid: string) => {
@@ -79,18 +81,25 @@ const workspaces: { [x: string]: any } = {
         return {
           fetch: async () => ({ available: false }),
           workerChannels: () => ({
-            fetch: async () => ({ availableCapacityPercentage: 1 }),
+            fetch: async () => ({ availableCapacityPercentage: 1, configuredCapacity: 2 }),
           }),
         };
 
       return {
-        fetch: async () => ({ available: true }),
+        fetch: async () => ({
+          available: true,
+          attributes: JSON.stringify({ maxMessageCapacity: configurableCapacity }),
+        }),
         workerChannels: (taskChannelUniqueName: string) => {
           if (taskChannelUniqueName === 'channel')
-            return { fetch: async () => ({ availableCapacityPercentage: 1 }) };
+            return {
+              fetch: async () => ({ availableCapacityPercentage: 1, configuredCapacity: 2 }),
+            };
 
           if (taskChannelUniqueName === 'channel2')
-            return { fetch: async () => ({ availableCapacityPercentage: 0 }) };
+            return {
+              fetch: async () => ({ availableCapacityPercentage: 0, configuredCapacity: 1 }),
+            };
 
           throw new Error('Channel does not exists');
         },

--- a/tests/transferChatStart.test.ts
+++ b/tests/transferChatStart.test.ts
@@ -443,7 +443,6 @@ describe('transferChatStart (without maxMessageCapacity set)', () => {
 
       expect(result).toBeDefined();
       const response = result as MockedResponse;
-      console.log(response);
       expect(response.getStatus()).toBe(200);
       expect(response.getBody()).toStrictEqual(expected);
       expect(originalTask.attributes).toBe(expectedOldAttr);

--- a/tests/transferChatStart.test.ts
+++ b/tests/transferChatStart.test.ts
@@ -66,7 +66,7 @@ let tasks: any[] = [
 
 const channels: { [x: string]: string[] } = {};
 
-const configurableCapacity = 1;
+let configurableCapacity: number | undefined = 1;
 
 const workspaces: { [x: string]: any } = {
   WSxxx: {
@@ -166,22 +166,22 @@ const baseContext = {
   CHAT_SERVICE_SID: 'ISxxx',
 };
 
-describe('transferChatStart', () => {
-  beforeAll(() => {
-    helpers.setup({});
-  });
-  afterAll(() => {
-    helpers.teardown();
-  });
+beforeAll(() => {
+  helpers.setup({});
+});
+afterAll(() => {
+  helpers.teardown();
+});
 
-  beforeEach(() => {
-    channels.channel = ['worker1'];
-  });
+beforeEach(() => {
+  channels.channel = ['worker1'];
+});
 
-  afterEach(() => {
-    if (tasks.length > 2) tasks = tasks.slice(0, 2);
-  });
+afterEach(() => {
+  if (tasks.length > 2) tasks = tasks.slice(0, 2);
+});
 
+describe('transferChatStart (with maxMessageCapacity set)', () => {
   test('Should return status 400', async () => {
     const event1: Body = {
       taskSid: undefined,
@@ -359,6 +359,91 @@ describe('transferChatStart', () => {
 
       expect(result).toBeDefined();
       const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(response.getBody()).toStrictEqual(expected);
+      expect(originalTask.attributes).toBe(expectedOldAttr);
+      expect(originalTask.reason).toBe('task transferred');
+      expect(originalTask.assignmentStatus).toBe('wrapping');
+      expect(tasks).toHaveLength(3);
+      expect(newTask).toHaveProperty('sid');
+      expect(newTask.taskChannel).toBe(originalTask.taskChannelUniqueName);
+      expect(newTask.wokflowSid).toBe(originalTask.wokflowSid);
+      expect(newTask.attributes).toBe(expectedNewAttr);
+      expect(channels.channel).not.toContain('worker1');
+      expect(channels.channel).toContain('worker2');
+    };
+
+    await transferChatStart(baseContext, event, callback);
+  });
+});
+
+describe('transferChatStart (without maxMessageCapacity set)', () => {
+  configurableCapacity = undefined;
+
+  test('Should return status 403', async () => {
+    const event1: Body = {
+      taskSid: 'task1',
+      targetSid: 'WK offline worker',
+      ignoreAgent: 'worker1',
+      mode: 'COLD',
+      memberToKick: 'worker1',
+    };
+
+    const event2: Body = {
+      taskSid: 'task2',
+      targetSid: 'WKxxx',
+      ignoreAgent: 'worker1',
+      mode: 'COLD',
+      memberToKick: 'worker1',
+    };
+
+    const callback1: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(403);
+      expect(response.getBody().message).toContain("Error: can't transfer to an offline counselor");
+    };
+
+    const callback2: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(403);
+      expect(response.getBody().message).toContain('Error: counselor has no available capacity');
+    };
+
+    await transferChatStart(baseContext, event1, callback1);
+    await transferChatStart(baseContext, event2, callback2);
+  });
+
+  test('Should return status 200 (COLD withouth having maxMessageCapacity)', async () => {
+    // reset task attributes
+    await tasks[0].update({
+      attributes: '{"channelSid":"channel"}',
+      assignmentStatus: undefined,
+      reason: undefined,
+    });
+
+    const event: Body = {
+      taskSid: 'task1',
+      targetSid: 'WKxxx',
+      ignoreAgent: 'worker1',
+      mode: 'COLD',
+      memberToKick: 'worker1',
+    };
+    const expectedOldAttr =
+      '{"channelSid":"CH00000000000000000000000000000000","proxySessionSID":"KC00000000000000000000000000000000"}';
+    const expectedNewAttr =
+      '{"channelSid":"channel","conversations":{"conversation_id":"task1"},"ignoreAgent":"worker1","targetSid":"WKxxx","transferTargetType":"worker"}';
+
+    const expected = { taskSid: 'newTaskSid' };
+
+    const callback: ServerlessCallback = (err, result) => {
+      const originalTask = tasks.find(t => t.sid === 'task1');
+      const newTask = tasks.find(t => t.sid === 'newTaskSid');
+
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      console.log(response);
       expect(response.getStatus()).toBe(200);
       expect(response.getBody()).toStrictEqual(expected);
       expect(originalTask.attributes).toBe(expectedOldAttr);


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-256
This PR is related to: https://github.com/tech-matters/flex-plugins/pull/219

- Moved chat channel finding logic to the `adjustChatCapacity` function.
- Added integration for manual pull with transfers: if a counselor has availavable `worker.attributes.maxMessageCapacity`, the chat channel capacity is increased from within `transferChatStart`.