### PR TITLE
Make the "Counselor has left the chat" message consistent across all text-based channels

### DIFF
--- a/functions/sendSystemMessage.ts
+++ b/functions/sendSystemMessage.ts
@@ -1,0 +1,66 @@
+import '@twilio-labs/serverless-runtime-types';
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  error400,
+  error500,
+  success,
+} from '@tech-matters/serverless-helpers';
+
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: string;
+  CHAT_SERVICE_SID: string;
+};
+
+export type Body = {
+  taskSid?: string;
+  message?: string;
+  from?: string
+};
+
+export const handler: ServerlessFunctionSignature = TokenValidator(
+  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+
+    const { taskSid, message, from } = event;
+
+    try {
+      if (taskSid === undefined) {
+        resolve(error400('taskSid'));
+        return;
+      }
+
+      if (message === undefined) {
+        resolve(error400('message'));
+        return;
+      }
+
+      const client = context.getTwilioClient();
+
+      const task = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks(taskSid)
+        .fetch();
+      const taskToCloseAttributes = JSON.parse(task.attributes);
+      const { channelSid } = taskToCloseAttributes;
+
+      await client.chat
+        .services(context.CHAT_SERVICE_SID)
+        .channels(channelSid)
+        .messages.create({ body: message, from });
+
+      resolve(success('Message sent'));
+    } catch (err) {
+      resolve(error500(err));
+    }
+  },
+);

--- a/functions/sendSystemMessage.ts
+++ b/functions/sendSystemMessage.ts
@@ -16,14 +16,13 @@ const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 
 type EnvVars = {
   TWILIO_WORKSPACE_SID: string;
-  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: string;
   CHAT_SERVICE_SID: string;
 };
 
 export type Body = {
   taskSid?: string;
   message?: string;
-  from?: string
+  from?: string;
 };
 
 export const handler: ServerlessFunctionSignature = TokenValidator(

--- a/tests/sendSystemMessage.test.ts
+++ b/tests/sendSystemMessage.test.ts
@@ -1,0 +1,130 @@
+import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { handler as sendSystemMessage, Body } from '../functions/sendSystemMessage';
+
+import helpers, { MockedResponse } from './helpers';
+
+const tasks: any[] = [
+  {
+    sid: 'task-123',
+    attributes: '{"channelSid":"channel-123"}',
+    fetch: async () => tasks.find(t => t.sid === 'task-123'),
+  },
+  {
+    sid: 'broken-task',
+    attributes: '{"channelSid":"non-existing"}',
+    fetch: async () => tasks.find(t => t.sid === 'broken-task'),
+  },
+];
+const channels: { [x: string]: any } = {
+  'channel-123': { messages: { create: jest.fn() } },
+};
+
+const workspaces: { [x: string]: any } = {
+  WSxxx: {
+    tasks: (taskSid: string) => {
+      const task = tasks.find(t => t.sid === taskSid);
+      if (task) return task;
+
+      throw new Error('Task does not exists');
+    },
+  },
+};
+
+const baseContext = {
+  getTwilioClient: (): any => ({
+    taskrouter: {
+      workspaces: (workspaceSID: string) => {
+        if (workspaces[workspaceSID]) return workspaces[workspaceSID];
+
+        throw new Error('Workspace does not exists');
+      },
+    },
+    chat: {
+      services: (serviceSid: string) => {
+        if (serviceSid === baseContext.CHAT_SERVICE_SID)
+          return {
+            channels: (channelSid: string) => {
+              if (channels[channelSid]) return channels[channelSid];
+
+              throw new Error('Error retrieving chat channel');
+            },
+          };
+
+        throw new Error('Error retrieving chat service');
+      },
+    },
+  }),
+  DOMAIN_NAME: 'serverless',
+  TWILIO_WORKSPACE_SID: 'WSxxx',
+  CHAT_SERVICE_SID: 'ISxxx',
+};
+
+describe('sendSystemMessage', () => {
+  beforeAll(() => {
+    const runtime = new helpers.MockRuntime({});
+    // eslint-disable-next-line no-underscore-dangle
+    helpers.setup({}, runtime);
+  });
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  test('Should return status 400', async () => {
+    const event1: Body = { taskSid: undefined };
+    const event2: Body = { taskSid: 'task-123', message: undefined };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(400);
+    };
+
+    await sendSystemMessage(baseContext, {}, callback);
+    await sendSystemMessage(baseContext, event1, callback);
+    await sendSystemMessage(baseContext, event2, callback);
+  });
+
+  test('Should return status 500', async () => {
+    const event1: Body = { taskSid: 'task-123', message: 'Something to say' };
+    const event2: Body = { taskSid: 'non-existing', message: 'Something to say' };
+    const event3: Body = { taskSid: 'broken-task', message: 'Something to say' };
+
+    const callback1: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Workspace does not exists');
+    };
+
+    const callback2: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Task does not exists');
+    };
+
+    const callback3: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Error retrieving chat channel');
+    };
+
+    const { getTwilioClient, DOMAIN_NAME } = baseContext;
+    await sendSystemMessage({ getTwilioClient, DOMAIN_NAME }, event1, callback1);
+    await sendSystemMessage(baseContext, event2, callback2);
+    await sendSystemMessage(baseContext, event3, callback3);
+  });
+
+  test('Should return status 200', async () => {
+    const event: Body = { taskSid: 'task-123', message: 'Something to say' };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+    };
+
+    await sendSystemMessage(baseContext, event, callback);
+  });
+});


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-314
This PR is related to
- https://github.com/tech-matters/webchat/pull/15
- https://github.com/tech-matters/flex-plugins/pull/349

This PR adds `sendSystemMessage` function, which takes in `taskSid`, `message` and (optionally) `from` parameters, and send a `message` to the channel bounded to the given `taskSid` in behalf of `from`. Default from is "system".