### PR TITLE
Add assignOfflineContact function

### DIFF
--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -73,9 +73,10 @@ export const handler: ServerlessFunctionSignature = TokenValidator(
         await targeWorker.update({ activitySid: availableActivity[0].sid });
 
         const reservations = await newTask.reservations().list();
-        if (reservations.length && reservations[0].workerSid === targetSid) {
-          await reservations[0].update({ reservationStatus: 'accepted' });
-          await reservations[0].update({ reservationStatus: 'completed' });
+        const reservation = reservations.find(r => r.workerSid === targetSid);
+        if (reservation) {
+          await reservation.update({ reservationStatus: 'accepted' });
+          await reservation.update({ reservationStatus: 'completed' });
         }
 
         await targeWorker.update({ activitySid: previousActivity });

--- a/functions/assignOfflineContact.ts
+++ b/functions/assignOfflineContact.ts
@@ -1,0 +1,95 @@
+import '@twilio-labs/serverless-runtime-types';
+import {
+  Context,
+  ServerlessCallback,
+  ServerlessFunctionSignature,
+} from '@twilio-labs/serverless-runtime-types/types';
+import {
+  responseWithCors,
+  bindResolve,
+  error400,
+  error500,
+  success,
+} from '@tech-matters/serverless-helpers';
+
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
+
+type EnvVars = {
+  TWILIO_WORKSPACE_SID: string;
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: string;
+};
+
+export type Body = {
+  targetSid?: string;
+  transferTargetType?: string;
+  helpline?: string;
+};
+
+export const handler: ServerlessFunctionSignature = TokenValidator(
+  async (context: Context<EnvVars>, event: Body, callback: ServerlessCallback) => {
+    const client = context.getTwilioClient();
+
+    const response = responseWithCors();
+    const resolve = bindResolve(callback)(response);
+
+    const { targetSid, transferTargetType, helpline } = event;
+
+    try {
+      if (targetSid === undefined) {
+        resolve(error400('targetSid'));
+        return;
+      }
+      if (transferTargetType === undefined) {
+        resolve(error400('transferTargetType'));
+        return;
+      }
+      if (helpline === undefined) {
+        resolve(error400('helpline'));
+        return;
+      }
+
+      const newAttributes = {
+        targetSid,
+        transferTargetType,
+        helpline,
+        channelType: 'default',
+        isContactlessTask: true,
+        isInMyBehalf: true,
+      };
+
+      // create New task
+      const newTask = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .tasks.create({
+          workflowSid: context.TWILIO_CHAT_TRANSFER_WORKFLOW_SID,
+          taskChannel: 'default',
+          attributes: JSON.stringify(newAttributes),
+          priority: 100,
+        });
+
+      const targeWorker = await client.taskrouter
+        .workspaces(context.TWILIO_WORKSPACE_SID)
+        .workers(targetSid)
+        .fetch();
+
+      // Set the worker available, assign the task, accept & complete it and set worker to previous state
+      if (!targeWorker.available) {
+        const previousActivity = targeWorker.activitySid;
+        const availableActivity = await client.taskrouter
+          .workspaces(context.TWILIO_WORKSPACE_SID)
+          .activities.list({ friendlyName: 'Available' });
+        await targeWorker.update({ activitySid: availableActivity[0].sid });
+        const reservations = await newTask.reservations().list();
+        if (reservations.length && reservations[0].workerSid === targetSid) {
+          await reservations[0].update({ reservationStatus: 'accepted' });
+          await reservations[0].update({ reservationStatus: 'completed' });
+        }
+        await targeWorker.update({ activitySid: previousActivity });
+      }
+
+      resolve(success(newTask));
+    } catch (err) {
+      resolve(error500(err));
+    }
+  },
+);

--- a/tests/assignOfflineContact.test.ts
+++ b/tests/assignOfflineContact.test.ts
@@ -1,0 +1,262 @@
+import { ServerlessCallback } from '@twilio-labs/serverless-runtime-types/types';
+import { handler as assignOfflineContact, Body } from '../functions/assignOfflineContact';
+
+import helpers, { MockedResponse } from './helpers';
+
+let tasks: any[] = [];
+
+const createTask = (sid: string, options: any) => {
+  return {
+    sid,
+    ...options,
+    reservations: () => ({
+      list: async () => [],
+    }),
+    remove: async () => {
+      tasks = tasks.filter(t => t.sid === sid);
+    },
+  };
+};
+
+const createReservation = (taskSid: string, workerSid: string) => {
+  const task = tasks.find(t => t.sid === taskSid);
+  const updateMock = jest.fn();
+  const withReservation = {
+    ...task,
+    reservations: () => ({
+      list: async () => [
+        {
+          workerSid,
+          update: updateMock,
+        },
+      ],
+    }),
+  };
+
+  tasks = tasks.map(t => (t.sid === taskSid ? withReservation : t));
+  return updateMock;
+};
+
+const updateWorkerMock = jest.fn();
+
+const workspaces: { [x: string]: any } = {
+  WSxxx: {
+    activities: {
+      list: async () => [
+        {
+          sid: 'Available',
+          friendlyName: 'Available',
+        },
+      ],
+    },
+    tasks: {
+      create: async (options: any) => {
+        const attributes = JSON.parse(options.attributes);
+        if (attributes.targetSid === 'intentionallyThrow')
+          throw new Error('Intentionally thrown error');
+
+        const newTask = createTask(Math.random().toString(), options);
+
+        tasks = [...tasks, newTask];
+
+        if (
+          ['available-worker-with-reservation', 'not-available-worker-with-reservation'].includes(
+            attributes.targetSid,
+          )
+        )
+          createReservation(newTask.sid, attributes.targetSid);
+
+        return tasks.find(t => t.sid === newTask.sid);
+      },
+    },
+    workers: (workerSid: string) => ({
+      fetch: () => {
+        if (workerSid === 'available-worker-no-reservation')
+          return {
+            sid: 'available-worker-no-reservation',
+            available: true,
+          };
+
+        if (workerSid === 'available-worker-with-reservation')
+          return {
+            sid: 'available-worker-with-reservation',
+            available: true,
+          };
+
+        if (workerSid === 'not-available-worker-no-reservation')
+          return {
+            attributes: JSON.stringify({}),
+            activitySid: 'activitySid',
+            sid: 'not-available-worker-with-reservation',
+            available: false,
+            update: updateWorkerMock,
+          };
+
+        if (workerSid === 'not-available-worker-with-reservation')
+          return {
+            attributes: JSON.stringify({}),
+            activitySid: 'activitySid',
+            sid: 'not-available-worker-with-reservation',
+            available: false,
+            update: updateWorkerMock,
+          };
+
+        throw new Error('Non existing worker');
+      },
+    }),
+  },
+};
+
+const baseContext = {
+  getTwilioClient: (): any => ({
+    taskrouter: {
+      workspaces: (workspaceSID: string) => {
+        if (workspaces[workspaceSID]) return workspaces[workspaceSID];
+
+        throw new Error('Workspace does not exists');
+      },
+    },
+  }),
+  DOMAIN_NAME: 'serverless',
+  TWILIO_WORKSPACE_SID: 'WSxxx',
+  TWILIO_CHAT_TRANSFER_WORKFLOW_SID: 'WWxxx',
+};
+
+beforeAll(() => {
+  helpers.setup({});
+});
+afterAll(() => {
+  helpers.teardown();
+});
+
+afterEach(() => {
+  tasks = [];
+  updateWorkerMock.mockClear();
+});
+
+describe('assignOfflineContact', () => {
+  test('Should return status 400', async () => {
+    const bad1: Body = {
+      targetSid: undefined,
+      finalTaskAttributes: JSON.stringify({}),
+    };
+    // @ts-ignore
+    const bad2: Body = {
+      targetSid: 'WKxxx',
+      // finalTaskAttributes: undefined,
+    };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(400);
+    };
+
+    await Promise.all(
+      [{}, bad1, bad2].map(event => assignOfflineContact(baseContext, event, callback)),
+    );
+  });
+
+  test('Should return status 500', async () => {
+    const event1: Body = {
+      targetSid: 'WKxxx',
+      finalTaskAttributes: JSON.stringify({}),
+    };
+
+    const event2: Body = {
+      targetSid: 'intentionallyThrow',
+      finalTaskAttributes: JSON.stringify({}),
+    };
+
+    const event3: Body = {
+      targetSid: 'non-existing-worker',
+      finalTaskAttributes: JSON.stringify({}),
+    };
+
+    const event4: Body = {
+      targetSid: 'available-worker-no-reservation',
+      finalTaskAttributes: JSON.stringify({}),
+    };
+
+    const event5: Body = {
+      targetSid: 'not-available-worker-no-reservation',
+      finalTaskAttributes: JSON.stringify({}),
+    };
+
+    const callback1: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Workspace does not exists');
+    };
+
+    const callback2: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Intentionally thrown error');
+    };
+
+    const callback3: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Non existing worker');
+    };
+
+    const callback4: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Error: reservation for task not created.');
+      expect(updateWorkerMock).not.toBeCalled();
+    };
+
+    const callback5: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(500);
+      expect(response.getBody().toString()).toContain('Error: reservation for task not created.');
+      expect(updateWorkerMock).toBeCalledTimes(2);
+    };
+
+    const { getTwilioClient, DOMAIN_NAME } = baseContext;
+    await assignOfflineContact({ getTwilioClient, DOMAIN_NAME }, event1, callback1);
+    await assignOfflineContact(baseContext, event2, callback2);
+    await assignOfflineContact(baseContext, event3, callback3);
+    await assignOfflineContact(baseContext, event4, callback4);
+    await assignOfflineContact(baseContext, event5, callback5);
+  });
+
+  test('Should return status 200 (available worker)', async () => {
+    const event: Body = {
+      targetSid: 'available-worker-with-reservation',
+      finalTaskAttributes: JSON.stringify({}),
+    };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(updateWorkerMock).not.toBeCalled();
+    };
+
+    await assignOfflineContact(baseContext, event, callback);
+  });
+
+  test('Should return status 200 (not available worker)', async () => {
+    const event: Body = {
+      targetSid: 'not-available-worker-with-reservation',
+      finalTaskAttributes: JSON.stringify({}),
+    };
+
+    const callback: ServerlessCallback = (err, result) => {
+      expect(result).toBeDefined();
+      const response = result as MockedResponse;
+      expect(response.getStatus()).toBe(200);
+      expect(updateWorkerMock).toBeCalledTimes(2);
+    };
+
+    await assignOfflineContact(baseContext, event, callback);
+  });
+});


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-500
This PR is related to https://github.com/tech-matters/flex-plugins/pull/361

This PR creates a new task in behalf of a target worker (counselor), in order to be consistent between HRM and Insights reports. 
- If the worker is offline, it's attributes are changed to apply a new routing rule that will prevent other tasks to be reserved (refer to Admin workflow in Development environment to see the complete assignment expression):
 `OR (worker.waitingOfflineContact == true AND worker.acceptOnlyTask == task.sid)`
- Even if the counselor is currently active and reached the assigned tasks limit, we have no need to increase channel capacity as we are using "default" channel for this kind of tasks.

Resolved questions:
- Q: Should a counselor be able to issue a contact in behalf of another counselor when the target is online?
  A: Yes.

~WIP~:
- ~Handle rules to avoid other tasks to be reserved in the short interval the target counselor is set to available.~
- ~Test~