### PR TITLE
[Development only][Reopen] Added operating info json and envar

### DIFF
--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           ssm_parameter: "DEV_TWILIO_AS_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+        with:
+          ssm_parameter: "DEV_TWILIO_AS_OPERATING_INFO_KEY"
+          env_variable_name: "OPERATING_INFO_KEY"
       - name: Create environment variable file
         run: |
           touch .env

--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -59,6 +59,8 @@ jobs:
         with:
           ssm_parameter: "DEV_TWILIO_AS_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+      - name: Set operating information file key
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
         with:
           ssm_parameter: "DEV_TWILIO_AS_OPERATING_INFO_KEY"
           env_variable_name: "OPERATING_INFO_KEY"

--- a/assets/operatingInfo/aselo-dev.json
+++ b/assets/operatingInfo/aselo-dev.json
@@ -5,13 +5,13 @@
   },
   "operatingHours": {
     "webchat": {
-      "1": [{ "open": 0, "close": 2359 }],
-      "2": [{ "open": 0, "close": 2359 }],
-      "3": [{ "open": 0, "close": 2359 }],
-      "4": [{ "open": 0, "close": 2359 }],
-      "5": [{ "open": 0, "close": 2359 }],
-      "6": [{ "open": 0, "close": 2359 }],
-      "7": [{ "open": 0, "close": 2359 }]
+      "1": [{ "open": 0, "close": 2400 }],
+      "2": [{ "open": 0, "close": 2400 }],
+      "3": [{ "open": 0, "close": 2400 }],
+      "4": [{ "open": 0, "close": 2400 }],
+      "5": [{ "open": 0, "close": 2400 }],
+      "6": [{ "open": 0, "close": 2400 }],
+      "7": [{ "open": 0, "close": 2400 }]
     },
     "facebook": {
       "1": [],

--- a/assets/operatingInfo/aselo-dev.json
+++ b/assets/operatingInfo/aselo-dev.json
@@ -1,0 +1,26 @@
+{
+  "timezone": "America/New_York",
+  "holidays": { 
+    "12/25/2021": "Christmas"
+  },
+  "operatingHours": {
+    "webchat": {
+      "1": [{ "open": 0, "close": 2359 }],
+      "2": [{ "open": 0, "close": 2359 }],
+      "3": [{ "open": 0, "close": 2359 }],
+      "4": [{ "open": 0, "close": 2359 }],
+      "5": [{ "open": 0, "close": 2359 }],
+      "6": [{ "open": 0, "close": 2359 }],
+      "7": [{ "open": 0, "close": 2359 }]
+    },
+    "facebook": {
+      "1": [],
+      "2": [],
+      "3": [],
+      "4": [],
+      "5": [],
+      "6": [],
+      "7": []
+    }
+  }
+}


### PR DESCRIPTION
This PR is a reopen of https://github.com/tech-matters/serverless/pull/40 (reverted due to an error in .yaml file).

This PR adds a json file with operating info for two channels: `webchat` is always open and `facebook` is always closed. The purpose of this is to allow the team to test the behavior of the function in our environment.

