### PR TITLE
Fix .yaml file not including env var 

### DIFF
--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -76,6 +76,7 @@ jobs:
           SYNC_SERVICE_API_SECRET=$SYNC_SERVICE_API_SECRET
           SYNC_SERVICE_SID=$SYNC_SERVICE_SID
           CHAT_SERVICE_SID=$CHAT_SERVICE_SID
+          OPERATING_INFO_KEY=$OPERATING_INFO_KEY
           EOT                                          
       # Runs a single command using the runners shell
       - name: Install dependencies for the twilio function


### PR DESCRIPTION
This PR fixes the GH action file for deploying to development. The variable was being loaded in the scope of the action but never pasted into the created `.env` file, thus it was not included in the serverless service.