### PR TITLE
Deploy actions updated with operating info keys

### DIFF
--- a/.github/workflows/aselo_beta.yml
+++ b/.github/workflows/aselo_beta.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_AS_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+      - name: Set operating information file key
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "PROD_TWILIO_AS_OPERATING_INFO_KEY"
+          env_variable_name: "OPERATING_INFO_KEY"
       - name: Create environment variable file
         run: |
           touch .env
@@ -71,6 +76,7 @@ jobs:
           SYNC_SERVICE_API_SECRET=$SYNC_SERVICE_API_SECRET
           SYNC_SERVICE_SID=$SYNC_SERVICE_SID
           CHAT_SERVICE_SID=$CHAT_SERVICE_SID
+          OPERATING_INFO_KEY=$OPERATING_INFO_KEY
           EOT 
       # Runs a single command using the runners shell
       - name: Install dependencies for the twilio function

--- a/.github/workflows/south_africa_production.yml
+++ b/.github/workflows/south_africa_production.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_ZA_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+      - name: Set operating information file key
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "PROD_TWILIO_ZA_OPERATING_INFO_KEY"
+          env_variable_name: "OPERATING_INFO_KEY"
       - name: Create environment variable file
         run: |
           touch .env
@@ -71,6 +76,7 @@ jobs:
           SYNC_SERVICE_API_SECRET=$SYNC_SERVICE_API_SECRET
           SYNC_SERVICE_SID=$SYNC_SERVICE_SID
           CHAT_SERVICE_SID=$CHAT_SERVICE_SID
+          OPERATING_INFO_KEY=$OPERATING_INFO_KEY
           EOT           
       # Runs a single command using the runners shell
       - name: Install dependencies for the twilio function

--- a/.github/workflows/south_africa_staging.yml
+++ b/.github/workflows/south_africa_staging.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_ZA_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+      - name: Set operating information file key
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "STG_TWILIO_ZA_OPERATING_INFO_KEY"
+          env_variable_name: "OPERATING_INFO_KEY"
       - name: Create environment variable file
         run: |
           touch .env
@@ -71,6 +76,7 @@ jobs:
           SYNC_SERVICE_API_SECRET=$SYNC_SERVICE_API_SECRET
           SYNC_SERVICE_SID=$SYNC_SERVICE_SID
           CHAT_SERVICE_SID=$CHAT_SERVICE_SID
+          OPERATING_INFO_KEY=$OPERATING_INFO_KEY
           EOT           
       # Runs a single command using the runners shell
       - name: Install dependencies for the twilio function

--- a/.github/workflows/test_staging.yml
+++ b/.github/workflows/test_staging.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_TEST_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+      - name: Set operating information file key
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "STG_TWILIO_TEST_OPERATING_INFO_KEY"
+          env_variable_name: "OPERATING_INFO_KEY"
       - name: Create environment variable file
         run: |
           touch .env
@@ -71,6 +76,7 @@ jobs:
           SYNC_SERVICE_API_SECRET=$SYNC_SERVICE_API_SECRET
           SYNC_SERVICE_SID=$SYNC_SERVICE_SID
           CHAT_SERVICE_SID=$CHAT_SERVICE_SID
+          OPERATING_INFO_KEY=$OPERATING_INFO_KEY
           EOT           
       # Runs a single command using the runners shell
       - name: Install dependencies for the twilio function

--- a/.github/workflows/zambia_production.yml
+++ b/.github/workflows/zambia_production.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           ssm_parameter: "PROD_TWILIO_ZM_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+      - name: Set operating information file key
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "PROD_TWILIO_ZM_OPERATING_INFO_KEY"
+          env_variable_name: "OPERATING_INFO_KEY"
       - name: Create environment variable file
         run: |
           touch .env
@@ -71,6 +76,7 @@ jobs:
           SYNC_SERVICE_API_SECRET=$SYNC_SERVICE_API_SECRET
           SYNC_SERVICE_SID=$SYNC_SERVICE_SID
           CHAT_SERVICE_SID=$CHAT_SERVICE_SID
+          OPERATING_INFO_KEY=$OPERATING_INFO_KEY
           EOT
       # Runs a single command using the runners shell
       - name: Install dependencies for the twilio function

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           ssm_parameter: "STG_TWILIO_ZM_WORKSPACE_SID"
           env_variable_name: "TWILIO_WORKSPACE_SID"
+      - name: Set operating information file key
+        uses: "marvinpinto/action-inject-ssm-secrets@latest"
+        with:
+          ssm_parameter: "STG_TWILIO_ZM_OPERATING_INFO_KEY"
+          env_variable_name: "OPERATING_INFO_KEY"
       - name: Create environment variable file
         run: |
           touch .env
@@ -71,6 +76,7 @@ jobs:
           SYNC_SERVICE_API_SECRET=$SYNC_SERVICE_API_SECRET
           SYNC_SERVICE_SID=$SYNC_SERVICE_SID
           CHAT_SERVICE_SID=$CHAT_SERVICE_SID
+          OPERATING_INFO_KEY=$OPERATING_INFO_KEY
           EOT           
       # Runs a single command using the runners shell
       - name: Install dependencies for the twilio function


### PR DESCRIPTION
This PR updates GH actions to include the corresponding key of each environment for operating hours file. Note that there is no ZM file, so calling the function without bundling the file first will result in an error.

Corresponding parameters already filled in AWS Parameter Store.